### PR TITLE
Fix the audit logic (#2409)

### DIFF
--- a/api-audit/src/main/java/com/capitalone/dashboard/common/CommonCodeReview.java
+++ b/api-audit/src/main/java/com/capitalone/dashboard/common/CommonCodeReview.java
@@ -152,7 +152,7 @@ public class CommonCodeReview {
      */
     public static boolean checkForServiceAccount(String userLdapDN, ApiSettings settings) {
         List<String> serviceAccountOU = settings.getServiceAccountOU();
-        if (!CollectionUtils.isEmpty(serviceAccountOU)) {
+        if (!CollectionUtils.isEmpty(serviceAccountOU) && StringUtils.isNotBlank(userLdapDN)) {
             try {
                 String userLdapDNParsed = LdapUtils.getStringValue(new LdapName(userLdapDN), "OU");
                 List<String> matches = serviceAccountOU.stream().filter(it -> it.contains(userLdapDNParsed)).collect(Collectors.toList());

--- a/api-audit/src/main/java/com/capitalone/dashboard/evaluator/CodeReviewEvaluator.java
+++ b/api-audit/src/main/java/com/capitalone/dashboard/evaluator/CodeReviewEvaluator.java
@@ -210,7 +210,7 @@ public class CodeReviewEvaluator extends Evaluator<CodeReviewAuditResponseV2> {
             reviewAuditResponseV2.addAuditStatus(CodeReviewAuditStatus.COMMITAUTHOR_EQ_SERVICEACCOUNT);
             auditIncrementVersionTag(reviewAuditResponseV2, commit, CodeReviewAuditStatus.DIRECT_COMMIT_NONCODE_CHANGE_SERVICE_ACCOUNT);
         } else {
-            auditIncrementVersionTag(reviewAuditResponseV2, commit, StringUtils.equals("unknown", commit.getScmAuthorLogin()) ? CodeReviewAuditStatus.DIRECT_COMMIT_NONCODE_CHANGE_SCM_AUTHOR_LOGIN_INVALID : CodeReviewAuditStatus.DIRECT_COMMIT_NONCODE_CHANGE_USER_ACCOUNT);
+            auditIncrementVersionTag(reviewAuditResponseV2, commit, StringUtils.equals("unknown", commit.getScmAuthorLogin()) ? CodeReviewAuditStatus.SCM_AUTHOR_LOGIN_INVALID : CodeReviewAuditStatus.DIRECT_COMMIT_NONCODE_CHANGE_USER_ACCOUNT);
 
         }
     }

--- a/api-audit/src/main/java/com/capitalone/dashboard/evaluator/CodeReviewEvaluatorLegacy.java
+++ b/api-audit/src/main/java/com/capitalone/dashboard/evaluator/CodeReviewEvaluatorLegacy.java
@@ -192,32 +192,37 @@ public class CodeReviewEvaluatorLegacy extends LegacyEvaluator {
         return allPeerReviews;
     }
 
-    private void auditIncrementVersionTag(CodeReviewAuditResponse codeReviewAuditResponse, Commit commit, CodeReviewAuditStatus directCommitIncrementVersionTagStatus) {
-        if (CommonCodeReview.matchIncrementVersionTag(commit.getScmCommitLog(), settings)) {
-            codeReviewAuditResponse.addAuditStatus(directCommitIncrementVersionTagStatus);
-        }else{
-            codeReviewAuditResponse.addAuditStatus(commit.isFirstEverCommit() ? CodeReviewAuditStatus.DIRECT_COMMITS_TO_BASE_FIRST_COMMIT : CodeReviewAuditStatus.DIRECT_COMMITS_TO_BASE);
-        }
-    }
-
     private void auditServiceAccountChecks(CodeReviewAuditResponse codeReviewAuditResponse, Commit commit) {
+        // Check for improper login info and add appropriate status.
         if (StringUtils.isEmpty(commit.getScmAuthorLDAPDN())) {
-            codeReviewAuditResponse.addAuditStatus(commit.isFirstEverCommit() ? CodeReviewAuditStatus.DIRECT_COMMITS_TO_BASE_FIRST_COMMIT : CodeReviewAuditStatus.DIRECT_COMMIT_NONCODE_CHANGE_SCM_AUTHOR_LOGIN_INVALID);
-        } else {
-            auditDirectCommits(codeReviewAuditResponse, commit);
+            codeReviewAuditResponse.addAuditStatus(CodeReviewAuditStatus.SCM_AUTHOR_LOGIN_INVALID);
         }
+
+        if(commit.isFirstEverCommit()) {
+            codeReviewAuditResponse.addAuditStatus(CodeReviewAuditStatus.DIRECT_COMMITS_TO_BASE_FIRST_COMMIT);
+        }
+
+        // Proceed with other Audits.
+        auditDirectCommits(codeReviewAuditResponse, commit);
     }
 
     private void auditDirectCommits(CodeReviewAuditResponse codeReviewAuditResponse, Commit commit) {
         if (CommonCodeReview.checkForServiceAccount(commit.getScmAuthorLDAPDN(), settings)) {
             codeReviewAuditResponse.addAuditStatus(CodeReviewAuditStatus.COMMITAUTHOR_EQ_SERVICEACCOUNT);
-            // check for increment version tag and flag Direct commit by Service account
+            // check for increment version tag and flag Direct commit by Service Account.
             auditIncrementVersionTag(codeReviewAuditResponse, commit, CodeReviewAuditStatus.DIRECT_COMMIT_NONCODE_CHANGE_SERVICE_ACCOUNT);
         } else {
-            //if the scmAuthorLogin is unknown then return error status.
+            // check for increment version tag and flag Direct commit by User Account.
             auditIncrementVersionTag(codeReviewAuditResponse, commit, CodeReviewAuditStatus.DIRECT_COMMIT_NONCODE_CHANGE_USER_ACCOUNT);
         }
     }
 
+    private void auditIncrementVersionTag(CodeReviewAuditResponse codeReviewAuditResponse, Commit commit, CodeReviewAuditStatus directCommitIncrementVersionTagStatus) {
+        if (CommonCodeReview.matchIncrementVersionTag(commit.getScmCommitLog(), settings)) {
+            codeReviewAuditResponse.addAuditStatus(directCommitIncrementVersionTagStatus);
+        }else if(!commit.isFirstEverCommit()){
+            codeReviewAuditResponse.addAuditStatus(CodeReviewAuditStatus.DIRECT_COMMITS_TO_BASE);
+        }
+    }
 
 }

--- a/api-audit/src/main/java/com/capitalone/dashboard/status/CodeReviewAuditStatus.java
+++ b/api-audit/src/main/java/com/capitalone/dashboard/status/CodeReviewAuditStatus.java
@@ -43,5 +43,5 @@ public enum CodeReviewAuditStatus {
 
     NO_COMMIT_FOR_DATE_RANGE, //Removew this later when we can remove legacy peer review
     COMMIT_AFTER_PR_MERGE, COLLECTOR_ITEM_ERROR,
-    DIRECT_COMMIT_NONCODE_CHANGE_SCM_AUTHOR_LOGIN_INVALID //passed when SCM AUTHOR is unavailable
+    SCM_AUTHOR_LOGIN_INVALID //passed when SCM AUTHOR is unavailable
 }

--- a/api-audit/src/test/java/com/capitalone/dashboard/common/CodeReviewEvaluatorLegecyTest.java
+++ b/api-audit/src/test/java/com/capitalone/dashboard/common/CodeReviewEvaluatorLegecyTest.java
@@ -98,7 +98,7 @@ public class CodeReviewEvaluatorLegecyTest {
         when(apiSettings.getServiceAccountOU()).thenReturn(TestConstants.USER_ACCOUNTS);
         when(apiSettings.getCommitLogIgnoreAuditRegEx()).thenReturn("(.)*(Increment_Version_Tag)(.)*");
         List<CodeReviewAuditResponse> responseV2 =  codeReviewEvaluatorLegacy.evaluate(makeCollectorItem(1),125634536,6235263,null);
-        Assert.assertEquals(true, responseV2.get(1).getAuditStatuses().contains(CodeReviewAuditStatus.DIRECT_COMMIT_NONCODE_CHANGE_SCM_AUTHOR_LOGIN_INVALID));
+        Assert.assertEquals(true, responseV2.get(1).getAuditStatuses().contains(CodeReviewAuditStatus.SCM_AUTHOR_LOGIN_INVALID));
     }
 
 

--- a/api-audit/src/test/resources/expected/0-new-repo.json
+++ b/api-audit/src/test/resources/expected/0-new-repo.json
@@ -9,7 +9,8 @@
     },
     {
         "auditStatuses": [
-            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT"
+            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT",
+            "SCM_AUTHOR_LOGIN_INVALID"
         ],
         "lastUpdated": 1516207276877,
         "commits": [

--- a/api-audit/src/test/resources/expected/1-direct-commit.json
+++ b/api-audit/src/test/resources/expected/1-direct-commit.json
@@ -9,8 +9,9 @@
     },
     {
         "auditStatuses": [
-            "DIRECT_COMMIT_NONCODE_CHANGE_SCM_AUTHOR_LOGIN_INVALID",
-            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT"
+            "SCM_AUTHOR_LOGIN_INVALID",
+            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT",
+            "DIRECT_COMMITS_TO_BASE"
         ],
         "lastUpdated": 1516207277235,
         "commits": [

--- a/api-audit/src/test/resources/expected/2-unreviewed-merge.json
+++ b/api-audit/src/test/resources/expected/2-unreviewed-merge.json
@@ -71,7 +71,8 @@
     },
     {
         "auditStatuses": [
-            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT"
+            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT",
+            "SCM_AUTHOR_LOGIN_INVALID"
         ],
         "lastUpdated": 1516207277660,
         "commits": [

--- a/api-audit/src/test/resources/expected/3-github-comment-merge.json
+++ b/api-audit/src/test/resources/expected/3-github-comment-merge.json
@@ -79,7 +79,8 @@
     },
     {
         "auditStatuses": [
-            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT"
+            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT",
+            "SCM_AUTHOR_LOGIN_INVALID"
         ],
         "lastUpdated": 1516207278122,
         "commits": [

--- a/api-audit/src/test/resources/expected/4-github-review-merge.json
+++ b/api-audit/src/test/resources/expected/4-github-review-merge.json
@@ -80,7 +80,8 @@
     },
     {
         "auditStatuses": [
-            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT"
+            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT",
+            "SCM_AUTHOR_LOGIN_INVALID"
         ],
         "lastUpdated": 1516207278547,
         "commits": [

--- a/api-audit/src/test/resources/expected/5-lgtm-self-merge.json
+++ b/api-audit/src/test/resources/expected/5-lgtm-self-merge.json
@@ -158,8 +158,9 @@
     },
     {
         "auditStatuses": [
-            "DIRECT_COMMIT_NONCODE_CHANGE_SCM_AUTHOR_LOGIN_INVALID",
-            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT"
+            "SCM_AUTHOR_LOGIN_INVALID",
+            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT",
+            "DIRECT_COMMITS_TO_BASE"
         ],
         "lastUpdated": 1516207278996,
         "commits": [

--- a/api-audit/src/test/resources/expected/6-lgtm-merge.json
+++ b/api-audit/src/test/resources/expected/6-lgtm-merge.json
@@ -87,8 +87,9 @@
     },
     {
         "auditStatuses": [
-            "DIRECT_COMMIT_NONCODE_CHANGE_SCM_AUTHOR_LOGIN_INVALID",
-            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT"
+            "SCM_AUTHOR_LOGIN_INVALID",
+            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT",
+            "DIRECT_COMMITS_TO_BASE"
         ],
         "lastUpdated": 1516207279403,
         "commits": [

--- a/api-audit/src/test/resources/expected/MultipleAuthorsGHR.json
+++ b/api-audit/src/test/resources/expected/MultipleAuthorsGHR.json
@@ -236,7 +236,8 @@
     },
     {
         "auditStatuses": [
-            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT"
+            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT",
+            "SCM_AUTHOR_LOGIN_INVALID"
         ],
         "lastUpdated": 1517029042023,
         "commits": [

--- a/api-audit/src/test/resources/expected/MultipleAuthorsLGTM.json
+++ b/api-audit/src/test/resources/expected/MultipleAuthorsLGTM.json
@@ -122,7 +122,8 @@
     },
     {
         "auditStatuses": [
-            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT"
+            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT",
+            "SCM_AUTHOR_LOGIN_INVALID"
         ],
         "lastUpdated": 1516735761179,
         "commits": [

--- a/api-audit/src/test/resources/expected/NormalMerge.json
+++ b/api-audit/src/test/resources/expected/NormalMerge.json
@@ -97,8 +97,9 @@
     },
     {
         "auditStatuses": [
-            "DIRECT_COMMIT_NONCODE_CHANGE_SCM_AUTHOR_LOGIN_INVALID",
-            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT"
+            "SCM_AUTHOR_LOGIN_INVALID",
+            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT",
+            "DIRECT_COMMITS_TO_BASE"
         ],
         "lastUpdated": 1516207279841,
         "commits": [

--- a/api-audit/src/test/resources/expected/OpenBranchPr.json
+++ b/api-audit/src/test/resources/expected/OpenBranchPr.json
@@ -1,8 +1,9 @@
 [
     {
         "auditStatuses": [
-            "DIRECT_COMMIT_NONCODE_CHANGE_SCM_AUTHOR_LOGIN_INVALID",
-            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT"
+            "SCM_AUTHOR_LOGIN_INVALID",
+            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT",
+            "DIRECT_COMMITS_TO_BASE"
         ],
         "lastUpdated": 1516207281398,
         "commits": [

--- a/api-audit/src/test/resources/expected/OpenForkPr.json
+++ b/api-audit/src/test/resources/expected/OpenForkPr.json
@@ -1,8 +1,9 @@
 [
     {
         "auditStatuses": [
-            "DIRECT_COMMIT_NONCODE_CHANGE_SCM_AUTHOR_LOGIN_INVALID",
-            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT"
+            "SCM_AUTHOR_LOGIN_INVALID",
+            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT",
+            "DIRECT_COMMITS_TO_BASE"
         ],
         "lastUpdated": 1516207281058,
         "commits": [

--- a/api-audit/src/test/resources/expected/RebaseMerge.json
+++ b/api-audit/src/test/resources/expected/RebaseMerge.json
@@ -97,8 +97,9 @@
     },
     {
         "auditStatuses": [
-            "DIRECT_COMMIT_NONCODE_CHANGE_SCM_AUTHOR_LOGIN_INVALID",
-            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT"
+            "SCM_AUTHOR_LOGIN_INVALID",
+            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT",
+            "DIRECT_COMMITS_TO_BASE"
         ],
         "lastUpdated": 1516207280689,
         "commits": [

--- a/api-audit/src/test/resources/expected/SquashMerge.json
+++ b/api-audit/src/test/resources/expected/SquashMerge.json
@@ -97,8 +97,9 @@
     },
     {
         "auditStatuses": [
-            "DIRECT_COMMIT_NONCODE_CHANGE_SCM_AUTHOR_LOGIN_INVALID",
-            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT"
+            "SCM_AUTHOR_LOGIN_INVALID",
+            "DIRECT_COMMITS_TO_BASE_FIRST_COMMIT",
+            "DIRECT_COMMITS_TO_BASE"
         ],
         "lastUpdated": 1516207280261,
         "commits": [


### PR DESCRIPTION
* Model Changes to have additional metadata

* added unique field criteria as combination of jobName and jobUrl

* added code for sending DIRECT_COMMIT_NONCODE_CHANGE_SCM_AUTHOR_LOGIN_INVALID when scmAuthor is unknown

* Update CommonCodeReview.java

removed commented lines

* add Unix to allowed values in test

* Update CodeReviewEvaluatorLegacy.java

* added the review comments for the unknown login

* Update CodeReviewEvaluatorLegacy.java

* parameterized the read and connection timeouts

* Reverse Peer Review Logic - GHR takes precedence over LGTM

* Fix for sending DIRECT_COMMIT_NONCODE_CHANGE_SCM_AUTHOR_LOGIN_INVALID when login information is missing from github commit.

* Auditing logic refactor